### PR TITLE
feat(line-editor): add Ctrl+P / Ctrl+N history navigation

### DIFF
--- a/src/utils/terminal/line_editor.zig
+++ b/src/utils/terminal/line_editor.zig
@@ -796,6 +796,14 @@ pub const LineEditor = struct {
                     self.clearCompletionState();
                     try self.yank(); // Ctrl+Y - yank (paste from kill ring)
                 },
+                0x10 => {
+                    self.clearCompletionState();
+                    try self.historyPrevious(); // Ctrl+P - previous history (like Up arrow)
+                },
+                0x0E => {
+                    self.clearCompletionState();
+                    try self.historyNext(); // Ctrl+N - next history (like Down arrow)
+                },
                 0x1F => {
                     self.clearCompletionState();
                     try self.undo(); // Ctrl+_ (undo)


### PR DESCRIPTION
## What
Adds the standard readline/emacs **Ctrl+P** (previous) / **Ctrl+N** (next) history bindings. Den only bound Up/Down arrows; Ctrl+P/N are constant muscle memory for bash/zsh users.

Both wire to the existing `historyPrevious` / `historyNext`, so they mirror the arrows exactly (including completion-state clearing).

## Verification
- `zig build` clean.
- PTY test: after `echo ALPHA` then `echo BETA`, Ctrl+P recalls `echo BETA` and running it prints `BETA`.

8-line addition to the control-key dispatch in `src/utils/terminal/line_editor.zig`; no API changes.