### PR TITLE
feat(line-editor): support bracketed paste mode

### DIFF
--- a/src/utils/terminal/escape.zig
+++ b/src/utils/terminal/escape.zig
@@ -14,6 +14,8 @@ pub const EscapeSequence = enum {
     delete,
     page_up,
     page_down,
+    paste_start, // ESC[200~ (bracketed paste begin)
+    paste_end, // ESC[201~ (bracketed paste end)
     unknown,
 
     /// Parse escape sequence from input
@@ -36,23 +38,42 @@ pub const EscapeSequence = enum {
                 else => {},
             }
 
-            // Multi-character sequences
-            if (bytes.len >= 4 and bytes[3] == '~') {
-                switch (bytes[2]) {
-                    '3' => return .delete,
-                    '5' => return .page_up,
-                    '6' => return .page_down,
-                    else => {},
-                }
-            }
+            // Numeric-parameter sequences: ESC[<digits>~ (delete, paste, ...) and
+            // ESC[1;5C/D (ctrl arrows). bytes[2] is the first parameter digit.
+            // Return null while the parameter is still arriving so multi-digit
+            // codes like 200/201 (bracketed paste) are never truncated to .unknown.
+            if (bytes[2] >= '0' and bytes[2] <= '9') {
+                var idx: usize = 2;
+                while (idx < bytes.len and bytes[idx] >= '0' and bytes[idx] <= '9') : (idx += 1) {}
+                if (idx >= bytes.len) return null; // still reading digits
 
-            // Ctrl+Arrow sequences: ESC[1;5C (right) or ESC[1;5D (left)
-            if (bytes.len >= 6 and bytes[2] == '1' and bytes[3] == ';' and bytes[4] == '5') {
-                switch (bytes[5]) {
-                    'C' => return .ctrl_right,
-                    'D' => return .ctrl_left,
-                    else => {},
+                // ESC[<num>~
+                if (bytes[idx] == '~') {
+                    var num: u32 = 0;
+                    for (bytes[2..idx]) |d| num = num * 10 + (d - '0');
+                    return switch (num) {
+                        1 => .home,
+                        3 => .delete,
+                        4 => .end_key,
+                        5 => .page_up,
+                        6 => .page_down,
+                        200 => .paste_start,
+                        201 => .paste_end,
+                        else => .unknown,
+                    };
                 }
+
+                // ESC[1;5C / ESC[1;5D (ctrl arrows)
+                if (bytes[idx] == ';') {
+                    if (bytes.len < idx + 3) return null; // need ";5C"/";5D"
+                    return switch (bytes[idx + 2]) {
+                        'C' => .ctrl_right,
+                        'D' => .ctrl_left,
+                        else => .unknown,
+                    };
+                }
+
+                return .unknown;
             }
         }
 

--- a/src/utils/terminal/line_editor.zig
+++ b/src/utils/terminal/line_editor.zig
@@ -500,6 +500,13 @@ pub const LineEditor = struct {
         try self.terminal.enableRawMode();
         errdefer self.terminal.disableRawMode() catch {};
 
+        // Enable bracketed paste so the terminal wraps pasted text in
+        // ESC[200~ ... ESC[201~. The defer disables it on every exit path so we
+        // never leave the user's terminal stuck in bracketed-paste mode after
+        // Den hands control back. See handlePaste for how the text is consumed.
+        self.writeBytes("\x1B[?2004h") catch {};
+        defer self.writeBytes("\x1B[?2004l") catch {};
+
         // Reset state
         self.cursor = 0;
         self.length = 0;
@@ -1269,6 +1276,70 @@ pub const LineEditor = struct {
         }
     }
 
+    /// Consume a bracketed paste: after ESC[200~ we read raw bytes until the
+    /// ESC[201~ terminator and insert them as literal text. Embedded newlines are
+    /// inserted (normalized to spaces) rather than submitting the line, so
+    /// pasting a multi-line block never auto-executes — the footgun this prevents.
+    fn handlePaste(self: *LineEditor) !void {
+        self.saveUndoState();
+        self.clearHistorySearch();
+
+        // Terminator state machine for ESC [ 2 0 1 ~
+        const term = [_]u8{ 0x1B, '[', '2', '0', '1', '~' };
+        var matched: usize = 0;
+
+        while (true) {
+            const byte = (try self.terminal.readByte()) orelse {
+                // No byte ready yet — wait briefly; a paste arrives as a burst,
+                // so this only spins at the very end.
+                std.Io.sleep(std.Options.debug_io, std.Io.Duration.fromNanoseconds(@as(i96, 1_000_000)), .awake) catch {};
+                continue;
+            };
+
+            // Track progress toward the paste-end terminator.
+            if (byte == term[matched]) {
+                matched += 1;
+                if (matched == term.len) break; // full terminator seen
+                continue;
+            }
+
+            // Mismatch: bytes tentatively consumed as a partial terminator were
+            // actually pasted content — flush them, then reconsider this byte.
+            if (matched > 0) {
+                for (term[0..matched]) |pending| {
+                    self.insertPasteByte(pending);
+                }
+                matched = 0;
+                if (byte == term[0]) {
+                    matched = 1;
+                    continue;
+                }
+            }
+
+            self.insertPasteByte(byte);
+        }
+
+        try self.redrawLine();
+    }
+
+    /// Insert one pasted byte WITHOUT redrawing (handlePaste redraws once at the
+    /// end). Newline/CR/tab become a space so the paste stays on one editable
+    /// line and cannot submit itself.
+    fn insertPasteByte(self: *LineEditor, byte: u8) void {
+        if (self.length >= self.buffer.len) return;
+        const ch: u8 = switch (byte) {
+            '\n', '\r', '\t' => ' ',
+            else => byte,
+        };
+        var i: usize = self.length;
+        while (i > self.cursor) : (i -= 1) {
+            self.buffer[i] = self.buffer[i - 1];
+        }
+        self.buffer[self.cursor] = ch;
+        self.cursor += 1;
+        self.length += 1;
+    }
+
     fn deleteChar(self: *LineEditor) !void {
         if (self.cursor >= self.length) return;
 
@@ -1720,6 +1791,8 @@ pub const LineEditor = struct {
                 }
             },
             .delete => try self.deleteChar(),
+            .paste_start => try self.handlePaste(),
+            .paste_end => {}, // stray paste-end without a start: ignore
             else => {},
         }
     }


### PR DESCRIPTION
## What
Adds bracketed-paste support to the interactive line editor.

Pasting multi-line text without bracketed paste is a classic footgun: each embedded newline submits a line, so a pasted block runs **partially, line by line** — often executing something the user hadn't reviewed. Den had no paste handling at all.

- Enable the mode (`ESC[?2004h` on entry / `ESC[?2004l` on exit, via a `defer` so the terminal is always restored) so the terminal wraps pastes in `ESC[200~ … ESC[201~`.
- **escape.zig**: the CSI parameter parser only matched single-digit `ESC[N~` sequences and returned `.unknown` for anything longer — truncating `200`/`201` to `ESC[2` and dumping the rest as literal input. Rewrote that arm to scan the full numeric parameter, return `null` while digits are still arriving, then map `200~`→`paste_start`, `201~`→`paste_end` (existing `1/3/4/5/6` and `ESC[1;5C/D` ctrl-arrows preserved).
- **line_editor.zig**: `handlePaste()` reads up to the terminator via a small state machine and inserts the text in one batch (`insertPasteByte`, single redraw), normalizing embedded newline/CR/tab to spaces so the whole paste stays on one editable line and only runs on Enter.

## Verification
- `zig build` clean (exit 0).
- PTY test: pasting `echo LINE1\necho DANGER2` bracketed by `ESC[200~/201~` yields the single line `echo LINE1 echo DANGER2`; nothing executes before Enter (no `command not found`, no standalone `DANGER2`); `ESC[?2004h`/`l` emitted exactly once each.

Two files; additive; no API changes.